### PR TITLE
Fix: Map shows route when opening directions from Calendar or Next Class

### DIFF
--- a/frontend/src/screens/MapScreen.js
+++ b/frontend/src/screens/MapScreen.js
@@ -284,7 +284,7 @@ export default function MapScreen({ route }) {
   useEffect(() => {
     const location = route?.params?.nextClassLocation;
     const summary = route?.params?.nextClassSummary;
-    if (!location || !summary) return;
+    if (!location) return;
 
     setDestText(location);
     setStartText("My location");


### PR DESCRIPTION
## Summary
When opening the map from "Get Directions" (Calendar or Next Class), the start and destination fields were filled but no route was drawn and the directions panel did not open.

- Resolve event location (e.g. "H 435") to a campus building by matching the first token to building label; set destCoord so the Directions API can fetch the route.
- Open the directions panel when pre-filling from Calendar/Next Class so the route and "Go" are visible.
- Re-run pre-fill when userCoord becomes available so startCoord is set and the route fetches after location is ready.

## Test plan
- Profile → Calendar → pick a day with classes → "Get Directions" on a class → Map opens with route drawn and directions panel open; tap "Go" for turn-by-turn.
- Next Class ("No upcoming classes" → View Schedule) → same flow: route and panel appear on Map.