### PR TITLE
Handle invalid search input and show 'not found' feedback on indoor screen

### DIFF
--- a/frontend/__tests__/screens/IndoorDirectionsScreen.test.js
+++ b/frontend/__tests__/screens/IndoorDirectionsScreen.test.js
@@ -304,6 +304,38 @@ describe('IndoorDirectionsScreen', () => {
     expect(getAllByText(/Vanier Library/).length).toBeGreaterThan(0);
   });
 
+  // --- Invalid search / "not found" feedback ---
+
+  it('should show "not found" message when searching for a non-existent building', () => {
+    const { getByPlaceholderText, getByText } = render(
+      <IndoorDirectionsScreen route={mockRouteEmpty} navigation={mockNavigation} />
+    );
+    const startInput = getByPlaceholderText('Tap map or search start');
+    fireEvent(startInput, 'focus');
+    fireEvent.changeText(startInput, 'XYZABC Hall');
+    expect(getByText(/No rooms or buildings found/)).toBeTruthy();
+  });
+
+  it('should not show "not found" message when search is empty', () => {
+    const { getByPlaceholderText, queryByText } = render(
+      <IndoorDirectionsScreen route={mockRouteEmpty} navigation={mockNavigation} />
+    );
+    const startInput = getByPlaceholderText('Tap map or search start');
+    fireEvent(startInput, 'focus');
+    fireEvent.changeText(startInput, '');
+    expect(queryByText(/No rooms or buildings found/)).toBeNull();
+  });
+
+  it('should not show "not found" for whitespace-only search input', () => {
+    const { getByPlaceholderText, queryByText } = render(
+      <IndoorDirectionsScreen route={mockRouteEmpty} navigation={mockNavigation} />
+    );
+    const startInput = getByPlaceholderText('Tap map or search start');
+    fireEvent(startInput, 'focus');
+    fireEvent.changeText(startInput, '   ');
+    expect(queryByText(/No rooms or buildings found/)).toBeNull();
+  });
+
   // --- Empty prompt subtext ---
 
   it('should show subtext in empty prompt', () => {

--- a/frontend/__tests__/screens/IndoorMapScreen.test.js
+++ b/frontend/__tests__/screens/IndoorMapScreen.test.js
@@ -154,13 +154,43 @@ describe('IndoorMapScreen', () => {
     expect(getByText(/H837/)).toBeTruthy();
   });
 
-  it('should show no results for a non-matching query', () => {
+  it('should show "not found" message for a non-matching query', () => {
+    const { getByPlaceholderText, getByText } = render(
+      <IndoorMapScreen navigation={mockNavigation} />
+    );
+    const searchInput = getByPlaceholderText('Search room or click on map');
+    fireEvent.changeText(searchInput, 'XYZABC Hall');
+    expect(getByText(/No rooms or buildings found/)).toBeTruthy();
+  });
+
+  it('should not show "not found" message when search is empty', () => {
     const { getByPlaceholderText, queryByText } = render(
       <IndoorMapScreen navigation={mockNavigation} />
     );
     const searchInput = getByPlaceholderText('Search room or click on map');
-    fireEvent.changeText(searchInput, 'ZZZZZ');
-    expect(queryByText(/ZZZZZ.*Building/)).toBeNull();
+    fireEvent.changeText(searchInput, '');
+    expect(queryByText(/No rooms or buildings found/)).toBeNull();
+  });
+
+  it('should hide "not found" message after clearing search', () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <IndoorMapScreen navigation={mockNavigation} />
+    );
+    const searchInput = getByPlaceholderText('Search room or click on map');
+    fireEvent.changeText(searchInput, 'XYZABC');
+    expect(getByText(/No rooms or buildings found/)).toBeTruthy();
+    // Clear search
+    fireEvent.press(getByText('close'));
+    expect(queryByText(/No rooms or buildings found/)).toBeNull();
+  });
+
+  it('should handle whitespace-only search input gracefully', () => {
+    const { getByPlaceholderText, queryByText } = render(
+      <IndoorMapScreen navigation={mockNavigation} />
+    );
+    const searchInput = getByPlaceholderText('Search room or click on map');
+    fireEvent.changeText(searchInput, '   ');
+    expect(queryByText(/No rooms or buildings found/)).toBeNull();
   });
 
   it('should clear search when the close icon is pressed', () => {

--- a/frontend/src/screens/IndoorDirectionsScreen.js
+++ b/frontend/src/screens/IndoorDirectionsScreen.js
@@ -105,9 +105,9 @@ export default function IndoorDirectionsScreen({ route, navigation }) {
     const q = searchQuery.toLowerCase();
     return allRooms.filter(
       (r) =>
-        r.label?.toLowerCase().includes(q) ||
-        r.id?.toLowerCase().includes(q) ||
-        r.buildingName?.toLowerCase().includes(q)
+        (r.label || "").toLowerCase().includes(q) ||
+        (r.id || "").toLowerCase().includes(q) ||
+        (r.buildingName || "").toLowerCase().includes(q)
     );
   }, [searchQuery, allRooms]);
 
@@ -420,23 +420,32 @@ export default function IndoorDirectionsScreen({ route, navigation }) {
         )}
 
         {/* Search Results Dropdown */}
-        {searchResults.length > 0 && activeField && (
+        {searchQuery.trim().length > 0 && activeField && (
           <View style={styles.searchResultsContainer}>
-            <FlatList
-              data={searchResults.slice(0, 6)}
-              keyExtractor={(item) => item.id}
-              renderItem={({ item }) => (
-                <Pressable
-                  style={styles.searchResultItem}
-                  onPress={() => handleSelectRoom(item)}
-                >
-                  <Text style={styles.searchResultText}>
-                    {item.label}, Floor {item.floor?.split("-")[1] || item.floor} · {item.buildingName}
-                  </Text>
-                </Pressable>
-              )}
-              keyboardShouldPersistTaps="handled"
-            />
+            {searchResults.length > 0 ? (
+              <FlatList
+                data={searchResults.slice(0, 6)}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => (
+                  <Pressable
+                    style={styles.searchResultItem}
+                    onPress={() => handleSelectRoom(item)}
+                  >
+                    <Text style={styles.searchResultText}>
+                      {item.label}, Floor {item.floor?.split("-")[1] || item.floor} · {item.buildingName}
+                    </Text>
+                  </Pressable>
+                )}
+                keyboardShouldPersistTaps="handled"
+              />
+            ) : (
+              <View style={styles.noResultsContainer}>
+                <MaterialIcons name="search-off" size={24} color="#999" />
+                <Text style={styles.noResultsText}>
+                  No rooms or buildings found. Please try again.
+                </Text>
+              </View>
+            )}
           </View>
         )}
 
@@ -947,6 +956,17 @@ const styles = StyleSheet.create({
     marginTop: 4,
     fontSize: 12,
     color: "#bbb",
+    textAlign: "center",
+  },
+  noResultsContainer: {
+    alignItems: "center",
+    paddingVertical: 20,
+    paddingHorizontal: 16,
+  },
+  noResultsText: {
+    marginTop: 8,
+    fontSize: 14,
+    color: "#999",
     textAlign: "center",
   },
 });

--- a/frontend/src/screens/IndoorMapScreen.js
+++ b/frontend/src/screens/IndoorMapScreen.js
@@ -60,9 +60,9 @@ export default function IndoorMapScreen({ navigation }) {
     const normalizedQuery = searchQuery.toUpperCase().replace(/[^A-Z0-9]/g, "");
     return allRooms.filter(
       (r) =>
-        r.label.toLowerCase().includes(q) ||
-        r.id.toLowerCase().includes(q) ||
-        r.buildingName.toLowerCase().includes(q) ||
+        (r.label || "").toLowerCase().includes(q) ||
+        (r.id || "").toLowerCase().includes(q) ||
+        (r.buildingName || "").toLowerCase().includes(q) ||
         (r.searchKeys || []).some((key) => key.includes(normalizedQuery))
     );
   }, [searchQuery, allRooms]);
@@ -199,23 +199,32 @@ export default function IndoorMapScreen({ navigation }) {
         </View>
 
         {/* Search Results Dropdown */}
-        {searchResults.length > 0 && (
+        {searchQuery.trim().length > 0 && (
           <View style={styles.searchResultsContainer}>
-            <FlatList
-              data={searchResults.slice(0, 8)}
-              keyExtractor={(item) => item.id}
-              renderItem={({ item }) => (
-                <Pressable
-                  style={styles.searchResultItem}
-                  onPress={() => handleRoomSelect(item)}
-                >
-                  <Text style={styles.searchResultText}>
-                    {item.label} · {item.buildingName}
-                  </Text>
-                </Pressable>
-              )}
-              keyboardShouldPersistTaps="handled"
-            />
+            {searchResults.length > 0 ? (
+              <FlatList
+                data={searchResults.slice(0, 8)}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => (
+                  <Pressable
+                    style={styles.searchResultItem}
+                    onPress={() => handleRoomSelect(item)}
+                  >
+                    <Text style={styles.searchResultText}>
+                      {item.label} · {item.buildingName}
+                    </Text>
+                  </Pressable>
+                )}
+                keyboardShouldPersistTaps="handled"
+              />
+            ) : (
+              <View style={styles.noResultsContainer}>
+                <MaterialIcons name="search-off" size={24} color="#999" />
+                <Text style={styles.noResultsText}>
+                  No rooms or buildings found. Please try again.
+                </Text>
+              </View>
+            )}
           </View>
         )}
 
@@ -322,7 +331,7 @@ export default function IndoorMapScreen({ navigation }) {
               <View>
                 <Text style={styles.selectedRoomText}>Room Selected</Text>
                 <Text style={styles.selectedRoomDetail}>
-                  {selectedRoom.label} · Floor {currentFloor?.label} · {currentBuilding?.name}
+                  {selectedRoom.label || "Unknown"} · Floor {currentFloor?.label || "?"} · {currentBuilding?.name || "Unknown"}
                 </Text>
               </View>
             </View>
@@ -562,6 +571,17 @@ const styles = StyleSheet.create({
     marginTop: 8,
     fontSize: 14,
     color: "#999",
+  },
+  noResultsContainer: {
+    alignItems: "center",
+    paddingVertical: 20,
+    paddingHorizontal: 16,
+  },
+  noResultsText: {
+    marginTop: 8,
+    fontSize: 14,
+    color: "#999",
+    textAlign: "center",
   },
 
   // POI Legend


### PR DESCRIPTION
- Show 'No rooms or buildings found' message when search yields no results
- Guard against undefined properties in search filters and room display
- Whitespace-only input is treated as empty (no dropdown shown)
- Add tests: non-existent building search, empty input, whitespace input, clear search

closes #141 