### PR TITLE
Indoor voice segments

### DIFF
--- a/frontend/__tests__/screens/IndoorDirectionsScreen.test.js
+++ b/frontend/__tests__/screens/IndoorDirectionsScreen.test.js
@@ -6,6 +6,7 @@ import IndoorDirectionsScreen, {
   buildAllRooms,
   getSelectionForLocation,
   getInitialSelection,
+  prepareSegmentSpokenInstructions,
 } from '../../src/screens/IndoorDirectionsScreen';
 import { buildings } from '../../src/data/indoorFloorData';
 
@@ -181,6 +182,19 @@ describe('IndoorDirectionsScreen', () => {
     expect(selection.campusId).toBe('sgw');
     expect(selection.buildingIdx).toBe(1);
     expect(selection.floorIdx).toBe(1);
+  });
+
+  it('prepareSegmentSpokenInstructions should collapse consecutive generic hallway instructions', () => {
+    const spokenSteps = prepareSegmentSpokenInstructions([
+      'Continue along the corridor',
+      'Continue through the hallway',
+      'Take the stairs from Floor 2 to Floor 8',
+    ]);
+
+    expect(spokenSteps).toEqual([
+      'Continue along the corridor',
+      'Take the stairs from Floor 2 to Floor 8',
+    ]);
   });
 
   it('should render safely when the selected campus data is unavailable', () => {

--- a/frontend/src/screens/IndoorDirectionsScreen.js
+++ b/frontend/src/screens/IndoorDirectionsScreen.js
@@ -145,7 +145,7 @@ function isGenericHallwayInstruction(text = "") {
   );
 }
 
-function prepareSegmentSpokenInstructions(steps = []) {
+export function prepareSegmentSpokenInstructions(steps = []) {
   const normalizedSteps = steps
     .map((step) => normalizeSpokenInstructionText(step))
     .filter(Boolean);


### PR DESCRIPTION
Added segment-based voice navigation for indoor directions.
	•	Tapping a journey card plays voice instructions for that segment
	•	First segment includes start location, last includes arrival message
	•	Repeated instructions are cleaned up for smoother speech
	•	Switching segments stops current playback and starts the new one